### PR TITLE
Various fixed identified after the release

### DIFF
--- a/src/KlarnaOnsiteMessaging.php
+++ b/src/KlarnaOnsiteMessaging.php
@@ -97,7 +97,7 @@ class KlarnaOnsiteMessaging {
 	 */
 	public function kosm_installed_admin_notice() {
 		$plugin = 'klarna-onsite-messaging-for-woocommerce/klarna-onsite-messaging-for-woocommerce.php';
-		if ( is_plugin_active( $plugin ) || array_key_exists( $plugin, get_plugins() ) ) {
+		if ( is_plugin_active( $plugin ) ) {
 			$message = __( 'The "Klarna On-Site Messaging for WooCommerce" plugin is now integrated into Klarna Payments. Please disable the plugin.', 'klarna-onsite-messaging-for-woocommerce' );
 			printf( '<div class="notice notice-error"><p>%s</p></div>', esc_html( $message ) );
 

--- a/src/KlarnaOnsiteMessaging.php
+++ b/src/KlarnaOnsiteMessaging.php
@@ -133,7 +133,6 @@ class KlarnaOnsiteMessaging {
 		global $post;
 
 		$has_shortcode = ( ! empty( $post ) && has_shortcode( $post->post_content, 'onsite_messaging' ) );
-		// NOTE! The order of these expressions is important. Always begin by checking for shortcode as it can be placed virtually anywhere.
 		if ( ! ( $has_shortcode || is_product() || is_cart() ) ) {
 			return;
 		}

--- a/src/KlarnaOnsiteMessaging.php
+++ b/src/KlarnaOnsiteMessaging.php
@@ -133,7 +133,8 @@ class KlarnaOnsiteMessaging {
 		global $post;
 
 		$has_shortcode = ( ! empty( $post ) && has_shortcode( $post->post_content, 'onsite_messaging' ) );
-		if ( ! ( is_product() || is_cart() || ! $has_shortcode ) ) {
+		// NOTE! The order of these expressions is important. Always begin by checking for shortcode as it can be placed virtually anywhere.
+		if ( ! ( $has_shortcode || is_product() || is_cart() ) ) {
 			return;
 		}
 

--- a/src/Pages/Product.php
+++ b/src/Pages/Product.php
@@ -68,11 +68,11 @@ class Product extends Page {
 		if ( $this->enabled && is_product() ) {
 			$target   = apply_filters( 'klarna_onsite_messaging_product_target', $this->target );
 			$priority = apply_filters( 'klarna_onsite_messaging_product_priority', $this->priority );
-			add_action( $target, array( $this, 'parent::display_placement' ), $priority );
+			add_action( $target, array( $this, parent::class . '::display_placement' ), $priority );
 		}
 
 		if ( $this->custom_widget_enabled ) {
-			add_action( $this->custom_widget_target, array( $this, 'parent::display_placement' ), $this->custom_widget_priority );
+			add_action( $this->custom_widget_target, array( $this, parent::class . '::display_placement' ), $this->custom_widget_priority );
 		}
 	}
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -106,6 +106,7 @@ class Settings {
 			'options' => array(
 				'default' => __( 'Default', 'klarna-onsite-messaging-for-woocommerce' ),
 				'dark'    => __( 'Dark', 'klarna-onsite-messaging-for-woocommerce' ),
+				'custom'  => __( 'Custom', 'klarna-onsite-messaging-for-woocommerce' ),
 			),
 		);
 		$settings['onsite_messaging_enabled_cart']          = array(


### PR DESCRIPTION
- restore custom theme (previously known as "none") [task#](https://app.clickup.com/t/8694f4c8n)
- resolved deprecation warning in PHP 8.2.
- only display the banner if KOSM is enabled.
- the shortcode should now appear wherever used (even on non-shop page) [task#](https://app.clickup.com/t/8694dk6hj).