### PR TITLE
Add 'kosm_hide_placement' filter

### DIFF
--- a/src/KlarnaOnsiteMessaging.php
+++ b/src/KlarnaOnsiteMessaging.php
@@ -168,14 +168,15 @@ class KlarnaOnsiteMessaging {
 
 		if ( isset( $_GET['osmDebug'] ) ) {
 			$localize['debug_info'] = array(
-				'product'       => is_product(),
-				'cart'          => is_cart(),
-				'shortcode'     => $has_shortcode,
-				'data_client'   => ! ( empty( $this->settings->get( 'data_client_id' ) ) ),
-				'locale'        => Utility::get_locale_from_currency(),
-				'currency'      => get_woocommerce_currency(),
-				'library'       => ( wp_scripts() )->registered['klarna_onsite_messaging_sdk']->src ?? $region,
-				'base_location' => $base_location['country'],
+				'product'        => is_product(),
+				'cart'           => is_cart(),
+				'shortcode'      => $has_shortcode,
+				'data_client'    => ! ( empty( $this->settings->get( 'data_client_id' ) ) ),
+				'locale'         => Utility::get_locale_from_currency(),
+				'currency'       => get_woocommerce_currency(),
+				'library'        => ( wp_scripts() )->registered['klarna_onsite_messaging_sdk']->src ?? $region,
+				'base_location'  => $base_location['country'],
+				'hide_placement' => has_filter( 'kosm_hide_placement' ),
 			);
 
 			$product = Utility::get_product();

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -84,6 +84,11 @@ class Utility {
 			$purchase_amount = empty( $purchase_amount ) ? WC()->cart->get_total( 'kosm' ) * 100 : $purchase_amount;
 		}
 
+		// Allow the merchant to hide the placement based on the purchase amount.
+		if ( apply_filters( 'kosm_hide_placement', false, $purchase_amount ) ) {
+			return;
+		}
+
 		?>
 	<klarna-placement class=<?php echo esc_attr( $class ); ?>
 		data-preloaded="true"


### PR DESCRIPTION
Add the `kosm_hide_placement` filter to conditionally hide the placement based on the purchase amount.

I've opted to let the script remain enqueued in case the merchant want to manually add a placement, and to make debugging easier by making the `osmDebug` debug flag available.

https://app.clickup.com/t/865buwyz4