### PR TITLE
Make KOSM available wherever is_woocommerce

### DIFF
--- a/src/KlarnaOnsiteMessaging.php
+++ b/src/KlarnaOnsiteMessaging.php
@@ -133,7 +133,7 @@ class KlarnaOnsiteMessaging {
 		global $post;
 
 		$has_shortcode = ( ! empty( $post ) && has_shortcode( $post->post_content, 'onsite_messaging' ) );
-		if ( ! ( $has_shortcode || is_product() || is_cart() ) ) {
+		if ( ! ( $has_shortcode || is_cart() || is_woocommerce() ) ) {
 			return;
 		}
 

--- a/src/KlarnaOnsiteMessaging.php
+++ b/src/KlarnaOnsiteMessaging.php
@@ -180,6 +180,10 @@ class KlarnaOnsiteMessaging {
 				'hide_placement' => has_filter( 'kosm_hide_placement' ),
 			);
 
+			if ( 'EUR' === $localize['debug_info']['currency'] ) {
+				$localize['debug_info']['force_locale'] = has_filter( 'kosm_force_euro_locale' );
+			}
+
 			$product = Utility::get_product();
 			if ( ! empty( $product ) ) {
 				$type                                   = $product->get_type();


### PR DESCRIPTION
The previous controls were too strict, specifically, `$has_shortcode` will always evaluate to `false` if an Elementor shortcode is used. There is no way around this since Elementor doesn't expose this information to `has_shortcode`, and the [suggested workaround](https://github.com/elementor/elementor/issues/18126) doesn't work.

- check if `is_woocommerce`.
- inform whether `kosm_force_euro_locale` is enabled in `debug_info`. 

https://app.clickup.com/t/8695rr3q9