### PR TITLE
Avoid ID on null warning for get_product

### DIFF
--- a/src/Utility.php
+++ b/src/Utility.php
@@ -109,8 +109,16 @@ class Utility {
 		global $product;
 		global $post;
 
-		$product = is_a( $product, 'WC_Product' ) ? $product : wc_get_product( $post->ID );
-		return is_a( $product, 'WC_Product' ) ? $product : false;
+		if ( is_a( $product, 'WC_Product' ) ) {
+			return $product;
+		}
+
+		if ( isset( $post ) && is_a( $post, 'WP_Post' ) ) {
+			$product = wc_get_product( $post->ID );
+			return is_a( $product, 'WC_Product' ) ? $product : false;
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
An "Attempt to read property 'ID' on null" warning sometimes occur for some merchants in Utility.php. I assume that it's the $post that is sometimes not defined. Perhaps it can be remedied in a more clean way?