### PR TITLE
Run settings update on init

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fix
-* Resolved text domains sometimes loading too early, resulting in the notice "_load_textdomain_just_in_time was called incorrectly".
+* Resolved notice "_load_textdomain_just_in_time was called incorrectly".
 
 ------------------
 ## [1.3.1] - 2025-01-14

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+* Resolved text domains sometimes loading too early, resulting in the notice "_load_textdomain_just_in_time was called incorrectly".
 
 ------------------
 ## [1.3.1] - 2025-01-14

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -85,9 +85,17 @@ abstract class Page {
 	public function __construct( $settings, $properties ) {
 		$this->properties = $properties;
 		$this->settings   = $settings;
-
-		$this->update( $settings );
+		add_action( 'init', array( $this, 'init_settings' ), 10, 0 );
 		$this->enabled = ! empty( $this->placement_id );
+	}
+
+	/**
+	 * Initialize the settings.
+	 *
+	 * @return void
+	 */
+	public function init_settings() {
+		$this->update( $this->settings );
 	}
 
 	/**

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -85,8 +85,9 @@ abstract class Page {
 	public function __construct( $settings, $properties ) {
 		$this->properties = $properties;
 		$this->settings   = $settings;
+		$this->enabled    = ! empty( $this->placement_id );
+
 		add_action( 'init', array( $this, 'init_settings' ), 10, 0 );
-		$this->enabled = ! empty( $this->placement_id );
 	}
 
 	/**

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -85,7 +85,6 @@ abstract class Page {
 	public function __construct( $settings, $properties ) {
 		$this->properties = $properties;
 		$this->settings   = $settings;
-		$this->enabled    = ! empty( $this->placement_id );
 
 		add_action( 'init', array( $this, 'init_settings' ), 10, 0 );
 	}
@@ -97,6 +96,7 @@ abstract class Page {
 	 */
 	public function init_settings() {
 		$this->update( $this->settings );
+		$this->enabled = ! empty( $this->placement_id );
 	}
 
 	/**


### PR DESCRIPTION
Run settings update on init, to resolve text domain loading too early, resulting in the notice "Function _load_textdomain_just_in_time was called incorrectly...."