### PR TITLE
Reference to undefined variables and missing destructuring

### DIFF
--- a/src/Blocks/CartBlockIntegration.php
+++ b/src/Blocks/CartBlockIntegration.php
@@ -3,7 +3,6 @@ namespace Krokedil\KlarnaOnsiteMessaging\Blocks;
 
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationInterface;
 use Krokedil\KlarnaOnsiteMessaging\Utility;
-use Krokedil\KlarnaOnsiteMessaging\Settings;
 
 /**
  * Integration for Klarna Onsite Messaging Cart Block.
@@ -53,10 +52,11 @@ class CartBlockIntegration implements IntegrationInterface {
 	 * @return array
 	 */
 	public function get_script_data() {
+		$settings        = get_option( 'woocommerce_klarna_payments_settings', array() );
 		$key             = $settings['placement_data_key_cart'] ?? 'credit-promotion-badge';
 		$theme           = $settings['onsite_messaging_theme_cart'] ?? '';
 		$wc_cart_total   = WC()->cart ? WC()->cart->get_total( 'edit' ) : 0;
-		$purchase_amount = (int) ( round( floatval( str_replace( array( ',', '.' ), '', $wc_cart_total ) ) ) );
+		$purchase_amount = (int) ( round( \floatval( str_replace( array( ',', '.' ), '', $wc_cart_total ) ) ) );
 		$locale          = Utility::get_locale_from_currency();
 		return array(
 			'key'             => $key,

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -23,6 +23,12 @@ const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount, cart }) => {
 }
 
 const renderOSM = () => {
+    const { ExperimentalOrderMeta } = wc?.blocksCheckout || {}
+    if (!ExperimentalOrderMeta) {
+        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in wc.blocksCheckout — WooCommerce Blocks version may be incompatible.")
+        return
+    }
+
     const osmData = window.wc?.wcSettings?.getSetting("osm-cart-block-integration_data", {}) || {}
     return React.createElement(
         ExperimentalOrderMeta,

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -23,9 +23,9 @@ const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount, cart }) => {
 }
 
 const renderOSM = () => {
-    const { ExperimentalOrderMeta } = wc?.blocksCheckout || {}
+    const { ExperimentalOrderMeta } = window.wc?.blocksCheckout || {}
     if (!ExperimentalOrderMeta) {
-        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in wc.blocksCheckout — WooCommerce Blocks version may be incompatible.")
+        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in window.wc.blocksCheckout — WooCommerce Blocks version may be incompatible.")
         return
     }
 


### PR DESCRIPTION
- `ExperimentalOrderMeta` is referenced, but not destructured.
- The local `$settings` variable is referenced twice in the code without initializing it. However, since we have a `??`  operator, it doesn't crash, but will always default to the hard-coded value.

https://app.clickup.com/t/869d1vdxx