### PR TITLE
Version 2.1.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,14 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+------------------
+## [2.1.1] - 2026-04-27
 ### Fix
 * Fixed a reference to undefined `$settings` variable in the cart block integration.
 * Fixed incorrect script dependencies for the cart block — updated from `wp-blocks`/`wp-editor` to `wp-element`, `wp-i18n`, `wc-blocks-registry`, and `jquery`.
 * Fixed `ExperimentalOrderMeta` destructuring to pull from `window.wc.blocksCheckout` with a safety check for undefined.
 * Fixed cart being replaced with a dummy element when KOSM is enabled on the blocks cart page.
 * Improved null/undefined checking in the cart block component.
-
-------------------
+ 
 ## [2.1.0] - 2026-02-02
 ### Added
 * Added support for On-Site messaging on the blocks cart page.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+* Fixed a reference to undefined `$settings` variable in the cart block integration.
+* Fixed incorrect script dependencies for the cart block — updated from `wp-blocks`/`wp-editor` to `wp-element`, `wp-i18n`, `wc-blocks-registry`, and `jquery`.
+* Fixed `ExperimentalOrderMeta` destructuring to pull from `window.wc.blocksCheckout` with a safety check for undefined.
+* Fixed cart being replaced with a dummy element when KOSM is enabled on the blocks cart page.
+* Improved null/undefined checking in the cart block component.
+
 ------------------
 ## [2.1.0] - 2026-02-02
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "name": "krokedil/klarna-onsite-messaging",
     "description": "Klarna On-Site Messaging for WooCommerce",
     "type": "library",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "require-dev": {
         "php-stubs/woocommerce-stubs": "^8.3",
         "10up/wp_mock": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3aebeeefade8dfcc808fcba823d8e85e",
+    "content-hash": "d563057ab0cccc9667bc25dfee048f58",
     "packages": [],
     "packages-dev": [
         {
@@ -691,16 +691,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.0",
+            "version": "v6.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a"
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
-                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
                 "shasum": ""
             },
             "conflict": {
@@ -711,9 +711,10 @@
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
                 "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
             },
@@ -736,9 +737,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.0"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
             },
-            "time": "2025-12-03T23:06:24+00:00"
+            "time": "2026-02-03T19:29:21+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -2554,15 +2555,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~7.4 || ~8.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "author": "Krokedil <info@krokedil.se>",
   "repository": "git@github.com:krokedil/klarna-onsite-messaging.git",
   "scripts": {
-    "lint": "pnpx prettier src/assets/js --paren-spacing --tab-width 4 --print-width 120 --no-semi --write",
-    "build": "npm run lint"
+    "lint": "pnpx prettier src/assets/js --paren-spacing --tab-width 4 --print-width 120 --write",
+    "build": "pnpm lint"
   },
   "devDependencies": {
     "prettier": "npm:wp-prettier@^3.0.3"

--- a/src/Blocks/CartBlockIntegration.php
+++ b/src/Blocks/CartBlockIntegration.php
@@ -25,7 +25,7 @@ class CartBlockIntegration implements IntegrationInterface {
 	 */
 	public function initialize() {
 		$script_path = plugin_dir_url( __DIR__ ) . 'assets/js/osm-cart-block-integration.js';
-		wp_register_script( 'osm-cart-block-integration-script', $script_path, array( 'wp-blocks', 'wp-element', 'wp-editor' ), KOSM_VERSION, true );
+		wp_register_script( 'osm-cart-block-integration-script', $script_path, array( 'wp-plugins', 'wp-element' ), KOSM_VERSION, true );
 	}
 
 	/**

--- a/src/Blocks/CartBlockIntegration.php
+++ b/src/Blocks/CartBlockIntegration.php
@@ -3,7 +3,6 @@ namespace Krokedil\KlarnaOnsiteMessaging\Blocks;
 
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationInterface;
 use Krokedil\KlarnaOnsiteMessaging\Utility;
-use Krokedil\KlarnaOnsiteMessaging\Settings;
 
 /**
  * Integration for Klarna Onsite Messaging Cart Block.
@@ -53,10 +52,11 @@ class CartBlockIntegration implements IntegrationInterface {
 	 * @return array
 	 */
 	public function get_script_data() {
+		$settings        = get_option( 'woocommerce_klarna_payments_settings', array() );
 		$key             = $settings['placement_data_key_cart'] ?? 'credit-promotion-badge';
 		$theme           = $settings['onsite_messaging_theme_cart'] ?? '';
 		$wc_cart_total   = WC()->cart ? WC()->cart->get_total( 'edit' ) : 0;
-		$purchase_amount = (int) ( round( floatval( str_replace( array( ',', '.' ), '', $wc_cart_total ) ) ) );
+		$purchase_amount = (int) ( round( \floatval( str_replace( array( ',', '.' ), '', $wc_cart_total ) ) ) );
 		$locale          = Utility::get_locale_from_currency();
 		return array(
 			'key'             => $key,

--- a/src/Blocks/CartBlockIntegration.php
+++ b/src/Blocks/CartBlockIntegration.php
@@ -25,7 +25,7 @@ class CartBlockIntegration implements IntegrationInterface {
 	 */
 	public function initialize() {
 		$script_path = plugin_dir_url( __DIR__ ) . 'assets/js/osm-cart-block-integration.js';
-		wp_register_script( 'osm-cart-block-integration-script', $script_path, array( 'wp-plugins', 'wp-element' ), KOSM_VERSION, true );
+		wp_register_script( 'osm-cart-block-integration-script', $script_path, array( 'wp-plugins', 'wp-element', 'wp-data' ), KOSM_VERSION, true );
 	}
 
 	/**

--- a/src/Blocks/CartBlockIntegration.php
+++ b/src/Blocks/CartBlockIntegration.php
@@ -25,7 +25,7 @@ class CartBlockIntegration implements IntegrationInterface {
 	 */
 	public function initialize() {
 		$script_path = plugin_dir_url( __DIR__ ) . 'assets/js/osm-cart-block-integration.js';
-		wp_register_script( 'osm-cart-block-integration-script', $script_path, array( 'wp-plugins', 'wp-element', 'wp-data' ), KOSM_VERSION, true );
+		wp_register_script( 'osm-cart-block-integration-script', $script_path, array( 'wp-element', 'wp-i18n', 'wp-blocks', 'wc-blocks-registry', 'jquery' ), KOSM_VERSION, true );
 	}
 
 	/**

--- a/src/KlarnaOnsiteMessaging.php
+++ b/src/KlarnaOnsiteMessaging.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'KOSM_VERSION', '2.1.0' );
+define( 'KOSM_VERSION', '2.1.1' );
 
 /**
  * The orchestrator class.

--- a/src/assets/js/klarna-onsite-messaging.js
+++ b/src/assets/js/klarna-onsite-messaging.js
@@ -1,11 +1,11 @@
-const $ = jQuery
-let configData = {}
-const { klarna_interoperability } = await import("@klarna/interoperability_token")
-const params = document.getElementById("wp-script-module-data-@klarna/onsite_messaging")
+const $ = jQuery;
+let configData = {};
+const { klarna_interoperability } = await import("@klarna/interoperability_token");
+const params = document.getElementById("wp-script-module-data-@klarna/onsite_messaging");
 
 if (params?.textContent) {
     try {
-        configData = JSON.parse(params.textContent)
+        configData = JSON.parse(params.textContent);
     } catch {}
 }
 
@@ -17,76 +17,76 @@ const klarna_onsite_messaging = {
     refresh: function () {
         // Loop each placement and unmount.
         klarna_onsite_messaging.placements.forEach((placement) => {
-            placement.unmount()
-        })
+            placement.unmount();
+        });
 
-        klarna_onsite_messaging.mount()
+        klarna_onsite_messaging.mount();
     },
 
     check_variable: function () {
         if ($(".product-type-variable")[0] && $(".variation_id").val() === "0") {
             // Product is a variable product and variable is not set
-            return false
+            return false;
         }
-        return true
+        return true;
     },
 
     update_total_cart: function (price) {
         if (!price) {
-            price = Math.round($("#kosm_cart_total").val())
+            price = Math.round($("#kosm_cart_total").val());
         }
 
         if (!isNaN(price)) {
-            klarna_onsite_messaging.update_total_price(price * 100)
+            klarna_onsite_messaging.update_total_price(price * 100);
         }
     },
 
     update_total_variation: function (variation) {
-        let price = Math.round(variation.display_price * 100)
-        klarna_onsite_messaging.update_total_price(price)
+        let price = Math.round(variation.display_price * 100);
+        klarna_onsite_messaging.update_total_price(price);
     },
 
     update_total_price: function (price) {
         /* If the price is undefined, OSM won't appear. Let this be known. */
         if (!price) {
-            console.warn("OSM price error: ", price)
+            console.warn("OSM price error: ", price);
         }
 
         $("klarna-placement").each(function () {
-            $(this).attr("data-total_amount", price)
-            $(this).attr("data-purchase-amount", price)
-        })
+            $(this).attr("data-total_amount", price);
+            $(this).attr("data-purchase-amount", price);
+        });
 
-        klarna_onsite_messaging.refresh()
+        klarna_onsite_messaging.refresh();
     },
 
     debug_info: function () {
         if (/[?&]osmDebug/.test(location.search)) {
-            const d = klarna_onsite_messaging.params.debug_info
+            const d = klarna_onsite_messaging.params.debug_info;
 
             if (typeof d !== "undefined") {
-                console.log("%cDebug info: ", "color: #ff0000")
+                console.log("%cDebug info: ", "color: #ff0000");
                 for (const [key, value] of Object.entries(d)) {
-                    console.log(`${key}: ${value}`)
+                    console.log(`${key}: ${value}`);
                 }
 
                 if (
                     typeof window.KlarnaOnsiteService !== "undefined" &&
                     typeof window.KlarnaOnsiteService.loaded !== "undefined"
                 ) {
-                    console.log("Klarna loaded status: " + window.KlarnaOnsiteService.loaded)
+                    console.log("Klarna loaded status: " + window.KlarnaOnsiteService.loaded);
                 }
             }
         }
     },
 
     init: async function (e) {
-        klarna_onsite_messaging.params = configData
-        klarna_onsite_messaging.Klarna = klarna_interoperability.Klarna
-        klarna_onsite_messaging.debug_info()
+        klarna_onsite_messaging.params = configData;
+        klarna_onsite_messaging.Klarna = klarna_interoperability.Klarna;
+        klarna_onsite_messaging.debug_info();
 
         if (klarna_onsite_messaging.check_variable) {
-            klarna_onsite_messaging.mount()
+            klarna_onsite_messaging.mount();
         }
 
         $(document.body).on("updated_cart_totals", function () {
@@ -95,88 +95,88 @@ const klarna_onsite_messaging = {
                 type: "GET",
                 dataType: "json",
                 success: function (response) {
-                    console.log("success", response)
-                    klarna_onsite_messaging.update_total_cart(response.data)
+                    console.log("success", response);
+                    klarna_onsite_messaging.update_total_cart(response.data);
                 },
                 error: function (response) {
-                    console.log(response)
+                    console.log(response);
                 },
-            })
-        })
+            });
+        });
 
         $(document).on("found_variation", function (e, variation) {
-            klarna_onsite_messaging.update_total_variation(variation)
-        })
+            klarna_onsite_messaging.update_total_variation(variation);
+        });
 
         /* "WooCommerce Measurement Price Calculator". */
 
         // Measurement with a "total price". These have more than one field/unit.
         $(".total_price").on("wc-measurement-price-calculator-total-price-change", function (e, quantity, price) {
             if (price) {
-                klarna_onsite_messaging.update_total_price(Math.round(quantity * price * 100))
+                klarna_onsite_messaging.update_total_price(Math.round(quantity * price * 100));
             }
-        })
+        });
 
         // Triggered when the customer manually adjusts the quantity (rather than the measurements).
         $("form.cart").on("wc-measurement-price-calculator-quantity-changed", function (e, quantity) {
             if (quantity) {
-                price = 100 * quantity * parseFloat(wc_price_calculator_params.product_price)
-                klarna_onsite_messaging.update_total_price(price)
+                price = 100 * quantity * parseFloat(wc_price_calculator_params.product_price);
+                klarna_onsite_messaging.update_total_price(price);
             }
-        })
+        });
 
         // Measurements with a "product price". These have a single field/unit.
         // The product price does not account for quantity, instead we have to account for this when updating OSM.
         $(".product_price").on(
             "wc-measurement-price-calculator-product-price-change",
             function (e, measurement, price) {
-                quantity = parseInt($("form.cart .qty").val())
+                quantity = parseInt($("form.cart .qty").val());
                 if (price && quantity > 0) {
-                    klarna_onsite_messaging.update_total_price(Math.round(price * 100 * quantity))
+                    klarna_onsite_messaging.update_total_price(Math.round(price * 100 * quantity));
                 }
             },
-        )
+        );
 
         $("form.cart").on("change", "input.qty", function () {
             if (typeof wc_price_calculator_params === "undefined") {
-                return
+                return;
             }
 
-            quantity = this.value
-            unit_price = parseFloat($(".product_price span").text()) // NaN - if the customer has not yet entered any units in the MPC fields.
+            quantity = this.value;
+            unit_price = parseFloat($(".product_price span").text()); // NaN - if the customer has not yet entered any units in the MPC fields.
 
             if (quantity > 0) {
-                price = 100 * quantity * parseFloat(wc_price_calculator_params.product_price)
+                price = 100 * quantity * parseFloat(wc_price_calculator_params.product_price);
                 if (!isNaN(unit_price)) {
-                    price = 100 * unit_price * quantity
+                    price = 100 * unit_price * quantity;
                 }
 
-                klarna_onsite_messaging.update_total_price(price)
+                klarna_onsite_messaging.update_total_price(price);
             }
-        })
+        });
     },
 
     mount: async function () {
-        const placements = document.querySelectorAll("klarna-placement")
+        const placements = document.querySelectorAll("klarna-placement");
 
         if (!placements.length) {
-            return
+            return;
         }
 
-        const klarnaPlacements = []
+        const klarnaPlacements = [];
         for (const placement of placements) {
             const tmpPlacement = klarna_onsite_messaging.Klarna.Messaging.placement({
                 key: placement.dataset.key,
                 amount: parseInt(placement.dataset.purchaseAmount),
                 locale: placement.dataset.locale,
                 theme: placement.dataset.theme || "default",
-            }).mount(placement)
-            klarnaPlacements.push(tmpPlacement)
+            }).mount(placement);
+            klarnaPlacements.push(tmpPlacement);
         }
 
-        klarna_onsite_messaging.placements = klarnaPlacements
+        klarna_onsite_messaging.placements = klarnaPlacements;
     },
-}
+};
 
-$("body").on("klarna_wc_sdk_loaded", klarna_onsite_messaging.init)
-window.klarna_onsite_messaging = klarna_onsite_messaging
+$("body").on("klarna_wc_sdk_loaded", klarna_onsite_messaging.init);
+window.klarna_onsite_messaging = klarna_onsite_messaging;

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -1,13 +1,14 @@
 const { registerPlugin: RegisterPluginOSM } = wp.plugins
 
-const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount, cart }) => {
+const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount }) => {
+    const { cartTotals } = window.wc.wcBlocksData.useStoreCart()
     const [showPlacement, setShowPlacement] = React.useState(true)
 
     React.useEffect(() => {
         if (window.klarna_onsite_messaging) {
-            window.klarna_onsite_messaging.update_total_price(cart.cartTotals.total_price)
+            window.klarna_onsite_messaging.update_total_price(cartTotals.total_price)
         }
-    }, [cart.cartTotals.total_price])
+    }, [cartTotals.total_price])
 
     return showPlacement
         ? React.createElement("klarna-placement", {

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -45,5 +45,5 @@ const renderOSM = () => {
 
 RegisterPluginOSM("osm-cart-block-integration", {
     render: renderOSM,
-    scope: "woocommerce-checkout",
+    scope: "woocommerce-cart",
 })

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -1,46 +1,34 @@
 const { registerPlugin: RegisterPluginOSM } = wp.plugins
+const { useSelect } = wp.data
 
 const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount }) => {
-    const { cartTotals } = window.wc.wcBlocksData.useStoreCart()
-    const [showPlacement, setShowPlacement] = React.useState(true)
+    const totalPrice = useSelect((select) => select("wc/store/cart").getCartTotals()?.total_price)
 
     React.useEffect(() => {
-        if (window.klarna_onsite_messaging) {
-            window.klarna_onsite_messaging.update_total_price(cartTotals.total_price)
+        if (window.klarna_onsite_messaging && totalPrice) {
+            window.klarna_onsite_messaging.update_total_price(totalPrice)
         }
-    }, [cartTotals.total_price])
+    }, [totalPrice])
 
-    return showPlacement
-        ? React.createElement("klarna-placement", {
-              className: "klarna-onsite-messaging",
-              "data-preloaded": "true",
-              class: "klarna-onsite-messaging",
-              "data-key": klarnaKey,
-              "data-locale": locale,
-              "data-theme": theme,
-              "data-purchase-amount": purchaseAmount,
-          })
-        : null
+    return React.createElement("klarna-placement", {
+        className: "klarna-onsite-messaging",
+        "data-preloaded": "true",
+        class: "klarna-onsite-messaging",
+        "data-key": klarnaKey,
+        "data-locale": locale,
+        "data-theme": theme,
+        "data-purchase-amount": purchaseAmount,
+    })
 }
 
 const renderOSM = () => {
-    const { ExperimentalOrderMeta } = window.wc?.blocksCheckout || {}
-    if (!ExperimentalOrderMeta) {
-        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in window.wc.blocksCheckout — WooCommerce Blocks version may be incompatible.")
-        return null
-    }
-
     const osmData = window.wc?.wcSettings?.getSetting("osm-cart-block-integration_data", {}) || {}
-    return React.createElement(
-        ExperimentalOrderMeta,
-        null,
-        React.createElement(ElementOSM, {
-            klarnaKey: osmData.key || "",
-            locale: osmData.locale || "",
-            theme: osmData.theme || "",
-            purchaseAmount: osmData.purchase_amount || "",
-        }),
-    )
+    return React.createElement(ElementOSM, {
+        klarnaKey: osmData.key || "",
+        locale: osmData.locale || "",
+        theme: osmData.theme || "",
+        purchaseAmount: osmData.purchase_amount || "",
+    })
 }
 
 RegisterPluginOSM("osm-cart-block-integration", {

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -1,36 +1,46 @@
 const { registerPlugin: RegisterPluginOSM } = wp.plugins
-const { useSelect } = wp.data
 
-const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount }) => {
-    const totalPrice = useSelect((select) => select("wc/store/cart").getCartTotals()?.total_price)
+const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount, cart }) => {
+    const [showPlacement, setShowPlacement] = React.useState(true)
 
     React.useEffect(() => {
-        if (window.klarna_onsite_messaging && totalPrice !== undefined && totalPrice !== null) {
-            window.klarna_onsite_messaging.update_total_price(totalPrice)
+        if (window.klarna_onsite_messaging) {
+            window.klarna_onsite_messaging.update_total_price(cart.cartTotals.total_price)
         }
-    }, [totalPrice])
+    }, [cart.cartTotals.total_price])
 
-    return React.createElement("klarna-placement", {
-        className: "klarna-onsite-messaging",
-        "data-preloaded": "true",
-        "data-key": klarnaKey,
-        "data-locale": locale,
-        "data-theme": theme,
-        "data-purchase-amount": purchaseAmount,
-    })
+    return showPlacement
+        ? React.createElement("klarna-placement", {
+              className: "klarna-onsite-messaging",
+              "data-preloaded": "true",
+              "data-key": klarnaKey,
+              "data-locale": locale,
+              "data-theme": theme,
+              "data-purchase-amount": purchaseAmount,
+          })
+        : null
 }
 
 const renderOSM = () => {
+    const { ExperimentalOrderMeta } = window.wc?.blocksCheckout || {};
+    if (!ExperimentalOrderMeta) {
+        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in window.wc.blocksCheckout")
+    }
+
     const osmData = window.wc?.wcSettings?.getSetting("osm-cart-block-integration_data", {}) || {}
-    return React.createElement(ElementOSM, {
-        klarnaKey: osmData.key || "",
-        locale: osmData.locale || "",
-        theme: osmData.theme || "",
-        purchaseAmount: osmData.purchase_amount || "",
-    })
+    return React.createElement(
+        ExperimentalOrderMeta,
+        null,
+        React.createElement(ElementOSM, {
+            klarnaKey: osmData.key || "",
+            locale: osmData.locale || "",
+            theme: osmData.theme || "",
+            purchaseAmount: osmData.purchase_amount || "",
+        }),
+    )
 }
 
 RegisterPluginOSM("osm-cart-block-integration", {
     render: renderOSM,
-    scope: "woocommerce-cart",
+    scope: "woocommerce-checkout",
 })

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -5,7 +5,7 @@ const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount }) => {
     const totalPrice = useSelect((select) => select("wc/store/cart").getCartTotals()?.total_price)
 
     React.useEffect(() => {
-        if (window.klarna_onsite_messaging && totalPrice) {
+        if (window.klarna_onsite_messaging && totalPrice !== undefined && totalPrice !== null) {
             window.klarna_onsite_messaging.update_total_price(totalPrice)
         }
     }, [totalPrice])

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -23,6 +23,12 @@ const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount, cart }) => {
 }
 
 const renderOSM = () => {
+    const { ExperimentalOrderMeta } = wc?.blocksCheckout || {}
+    if (!ExperimentalOrderMeta) {
+        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in wc.blocksCheckout — WooCommerce Blocks version may be incompatible.")
+        return
+    }
+
     const osmData = window.wc?.wcSettings?.getSetting("osm-cart-block-integration_data", {}) || {}
     return React.createElement(
         ExperimentalOrderMeta,

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -23,9 +23,9 @@ const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount, cart }) => {
 }
 
 const renderOSM = () => {
-    const { ExperimentalOrderMeta } = wc?.blocksCheckout || {}
+    const { ExperimentalOrderMeta } = window.wc?.blocksCheckout || {}
     if (!ExperimentalOrderMeta) {
-        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in wc.blocksCheckout — WooCommerce Blocks version may be incompatible.")
+        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in window.wc.blocksCheckout — WooCommerce Blocks version may be incompatible.")
         return
     }
 

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -13,7 +13,6 @@ const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount }) => {
     return React.createElement("klarna-placement", {
         className: "klarna-onsite-messaging",
         "data-preloaded": "true",
-        class: "klarna-onsite-messaging",
         "data-key": klarnaKey,
         "data-locale": locale,
         "data-theme": theme,

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -1,13 +1,13 @@
-const { registerPlugin: RegisterPluginOSM } = wp.plugins
+const { registerPlugin: RegisterPluginOSM } = wp.plugins;
 
 const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount, cart }) => {
-    const [showPlacement, setShowPlacement] = React.useState(true)
+    const [showPlacement, setShowPlacement] = React.useState(true);
 
     React.useEffect(() => {
         if (window.klarna_onsite_messaging) {
-            window.klarna_onsite_messaging.update_total_price(cart.cartTotals.total_price)
+            window.klarna_onsite_messaging.update_total_price(cart.cartTotals.total_price);
         }
-    }, [cart.cartTotals.total_price])
+    }, [cart.cartTotals.total_price]);
 
     return showPlacement
         ? React.createElement("klarna-placement", {
@@ -18,16 +18,16 @@ const ElementOSM = ({ klarnaKey, locale, theme, purchaseAmount, cart }) => {
               "data-theme": theme,
               "data-purchase-amount": purchaseAmount,
           })
-        : null
-}
+        : null;
+};
 
 const renderOSM = () => {
     const { ExperimentalOrderMeta } = window.wc?.blocksCheckout || {};
     if (!ExperimentalOrderMeta) {
-        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in window.wc.blocksCheckout")
+        console.warn("[Klarna OSM] ExperimentalOrderMeta not found in window.wc.blocksCheckout");
     }
 
-    const osmData = window.wc?.wcSettings?.getSetting("osm-cart-block-integration_data", {}) || {}
+    const osmData = window.wc?.wcSettings?.getSetting("osm-cart-block-integration_data", {}) || {};
     return React.createElement(
         ExperimentalOrderMeta,
         null,
@@ -37,10 +37,10 @@ const renderOSM = () => {
             theme: osmData.theme || "",
             purchaseAmount: osmData.purchase_amount || "",
         }),
-    )
-}
+    );
+};
 
 RegisterPluginOSM("osm-cart-block-integration", {
     render: renderOSM,
     scope: "woocommerce-checkout",
-})
+});

--- a/src/assets/js/osm-cart-block-integration.js
+++ b/src/assets/js/osm-cart-block-integration.js
@@ -27,7 +27,7 @@ const renderOSM = () => {
     const { ExperimentalOrderMeta } = window.wc?.blocksCheckout || {}
     if (!ExperimentalOrderMeta) {
         console.warn("[Klarna OSM] ExperimentalOrderMeta not found in window.wc.blocksCheckout — WooCommerce Blocks version may be incompatible.")
-        return
+        return null
     }
 
     const osmData = window.wc?.wcSettings?.getSetting("osm-cart-block-integration_data", {}) || {}


### PR DESCRIPTION
### Fix
* Fixed a reference to undefined `$settings` variable in the cart block integration.
* Fixed incorrect script dependencies for the cart block — updated from `wp-blocks`/`wp-editor` to `wp-element`, `wp-i18n`, `wc-blocks-registry`, and `jquery`.
* Fixed `ExperimentalOrderMeta` destructuring to pull from `window.wc.blocksCheckout` with a safety check for undefined.
* Fixed cart being replaced with a dummy element when KOSM is enabled on the blocks cart page.
* Improved null/undefined checking in the cart block component.