### PR TITLE
Use klarna network session instead of interoperability token

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Updated to use the Klarna network session token instead of an interoperability token.
 
 ------------------
 ## [2.1.2] - 2026-05-11

--- a/src/KlarnaOnsiteMessaging.php
+++ b/src/KlarnaOnsiteMessaging.php
@@ -184,7 +184,7 @@ class KlarnaOnsiteMessaging {
 		wp_deregister_script( 'onsite_messaging_script' );
 
 		$script_path = plugin_dir_url( __FILE__ ) . 'assets/js/klarna-onsite-messaging.js';
-		wp_register_script_module( '@klarna/onsite_messaging', $script_path, array( '@klarna/klarna_network_session_token' ), KOSM_VERSION );
+		wp_register_script_module( '@klarna/onsite_messaging', $script_path, array( '@klarna/network_session_token' ), KOSM_VERSION );
 
 		$localize = array(
 			'client_id'          => $client_id,

--- a/src/KlarnaOnsiteMessaging.php
+++ b/src/KlarnaOnsiteMessaging.php
@@ -184,7 +184,7 @@ class KlarnaOnsiteMessaging {
 		wp_deregister_script( 'onsite_messaging_script' );
 
 		$script_path = plugin_dir_url( __FILE__ ) . 'assets/js/klarna-onsite-messaging.js';
-		wp_register_script_module( '@klarna/onsite_messaging', $script_path, array( '@klarna/interoperability_token' ), KOSM_VERSION );
+		wp_register_script_module( '@klarna/onsite_messaging', $script_path, array( '@klarna/klarna_network_session_token' ), KOSM_VERSION );
 
 		$localize = array(
 			'client_id'          => $client_id,

--- a/src/assets/js/klarna-onsite-messaging.js
+++ b/src/assets/js/klarna-onsite-messaging.js
@@ -1,6 +1,6 @@
 const $ = jQuery;
 let configData = {};
-const { network_session } = await import("@klarna/klarna_network_session_token");
+const { network_session } = await import("@klarna/network_session_token");
 const params = document.getElementById("wp-script-module-data-@klarna/onsite_messaging");
 
 if (params?.textContent) {

--- a/src/assets/js/klarna-onsite-messaging.js
+++ b/src/assets/js/klarna-onsite-messaging.js
@@ -1,6 +1,6 @@
 const $ = jQuery;
 let configData = {};
-const { klarna_interoperability } = await import("@klarna/interoperability_token");
+const { network_session } = await import("@klarna/klarna_network_session_token");
 const params = document.getElementById("wp-script-module-data-@klarna/onsite_messaging");
 
 if (params?.textContent) {
@@ -82,7 +82,7 @@ const klarna_onsite_messaging = {
 
     init: async function (e) {
         klarna_onsite_messaging.params = configData;
-        klarna_onsite_messaging.Klarna = klarna_interoperability.Klarna;
+        klarna_onsite_messaging.Klarna = network_session.Klarna;
         klarna_onsite_messaging.debug_info();
 
         if (klarna_onsite_messaging.check_variable) {

--- a/src/assets/js/klarna-onsite-messaging.js
+++ b/src/assets/js/klarna-onsite-messaging.js
@@ -1,6 +1,6 @@
 const $ = jQuery;
 let configData = {};
-const { network_session } = await import("@klarna/network_session_token");
+const { klarna_interoperability } = await import("@klarna/network_session_token");
 const params = document.getElementById("wp-script-module-data-@klarna/onsite_messaging");
 
 if (params?.textContent) {
@@ -82,7 +82,7 @@ const klarna_onsite_messaging = {
 
     init: async function (e) {
         klarna_onsite_messaging.params = configData;
-        klarna_onsite_messaging.Klarna = network_session.Klarna;
+        klarna_onsite_messaging.Klarna = klarna_interoperability.Klarna;
         klarna_onsite_messaging.debug_info();
 
         if (klarna_onsite_messaging.check_variable) {


### PR DESCRIPTION
Update to use the Klarna network session token instead of an interoperability token.